### PR TITLE
Readme: Add quotes to provider publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also use the facade if you wish:
 Then, publish the configuration file using:
 
 ```cmd
-php artisan vendor:publish --provider=Stevebauman\Purify\PurifyServiceProvider
+php artisan vendor:publish --provider="Stevebauman\Purify\PurifyServiceProvider"
 ```
 
 ### Usage


### PR DESCRIPTION
The current docs state to run this command:

`php artisan vendor:publish --provider=Stevebauman\Purify\PurifyServiceProviders`

I'm on a fresh install and it publishes nothing for me. (Laravel claims "Publishing complete" but nothing happens). Adding double quotes works:

`php artisan vendor:publish --provider="Stevebauman\Purify\PurifyServiceProviders"`

Now Laravel says Publishing complete, but also mentions the config file was copied this time.

Cool repo btw!