### PR TITLE
Fix phpstan warning

### DIFF
--- a/src/Facades/Purify.php
+++ b/src/Facades/Purify.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Class Purify
  *
- * @method static clean($input, array $config = null)
+ * @static clean($input, array $config = null)
  */
 class Purify extends Facade
 {


### PR DESCRIPTION
Current annotation defines `clean()` as instance method, this triggers as error reported by [phpstan](https://github.com/phpstan/phpstan): `Static call to instance method Stevebauman\Purify\Facades\Purify::clean()` 