### PR TITLE
Specify return type in docbloc.

### DIFF
--- a/src/Facades/Purify.php
+++ b/src/Facades/Purify.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Class Purify
  *
- * @static clean($input, array $config = null)
+ * @static array|string clean($input, array $config = null)
  */
 class Purify extends Facade
 {


### PR DESCRIPTION
Not sure with other editors but Visual studio code is throwing a warning when using the `clean` method.