### PR TITLE
Enable multiple purifier settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,50 @@ then all rendered content will follow these sanization rules.
 
 ### Configuration
 
-Inside the configuration file, the entire settings array is passed directly
-to the HTML Purifier configuration, so feel free to customize it however
-you wish. You can specify multiple configuration sets as you desire.
+Inside the configuration file, multiple HTMLPurifier configuration sets
+can be specified, similar to Laravel's built-in `database`, `mail` and `logging` config.
 Simply call `Purify::config($name)->clean($input)` to use another set of configuration.
 
-For the configuration documentation, please visit the
-HTML Purifier Website:
+For HTMLPurifier configuration documentation, please visit the HTMLPurifier Website:
 
 http://htmlpurifier.org/live/configdoc/plain.html
+
+#### Custom HTML definitions
+
+The `Doctype` setting denotes the schema to ultimately abide to. You might want to extend these schema definitions
+to support custom elements or attributes (e.g. `<foo>...</foo>`, or `<span foo="...">`) by specifying a custom "definitions" class in config.
+We've already provided you with additional HTML5 definitions as HTMLPurifier does not (yet) support it out of the box.
+
+Here's an example for customizing the definitions in order to support Basecamp's Trix WYSIWYG editor (credit to [Antonio Primera](https://github.com/stevebauman/purify/issues/7)):
+
+```php
+<?php
+
+namespace App;
+
+use HTMLPurifier_HTMLDefinition;
+use Stevebauman\Purify\Definitions\Definition;
+
+class TrixPurifierDefinitions implements Definition
+{
+    public static function apply(HTMLPurifier_HTMLDefinition $definition)
+    {
+        $def->addElement('figure', 'Inline', 'Inline', 'Common');
+        $def->addAttribute('figure', 'class', 'Text');
+        $def->addElement('figcaption', 'Inline', 'Inline', 'Common');
+        $def->addAttribute('figcaption', 'class', 'Text');
+        $def->addAttribute('figcaption', 'data-trix-placeholder', 'Text');
+        $def->addAttribute('a', 'rel', 'Text');
+        $def->addAttribute('a', 'tabindex', 'Text');
+        $def->addAttribute('a', 'contenteditable', 'Enum#true,false');
+        $def->addAttribute('a', 'data-trix-attachment', 'Text');
+        $def->addAttribute('a', 'data-trix-content-type', 'Text');
+        $def->addAttribute('a', 'data-trix-id', 'Number');
+        $def->addElement('span', 'Block', 'Flow', 'Common');
+        $def->addAttribute('span', 'data-trix-cursor-target', 'Enum#right,left');
+        $def->addAttribute('span', 'data-trix-serialize', 'Enum#true,false');
+        $def->addAttribute('img', 'data-trix-mutable', 'Enum#true,false');
+        $def->addAttribute('img', 'data-trix-store-key', 'Text');
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -121,22 +121,25 @@ class TrixPurifierDefinitions implements Definition
 {
     public static function apply(HTMLPurifier_HTMLDefinition $definition)
     {
-        $def->addElement('figure', 'Inline', 'Inline', 'Common');
-        $def->addAttribute('figure', 'class', 'Text');
-        $def->addElement('figcaption', 'Inline', 'Inline', 'Common');
-        $def->addAttribute('figcaption', 'class', 'Text');
-        $def->addAttribute('figcaption', 'data-trix-placeholder', 'Text');
-        $def->addAttribute('a', 'rel', 'Text');
-        $def->addAttribute('a', 'tabindex', 'Text');
-        $def->addAttribute('a', 'contenteditable', 'Enum#true,false');
-        $def->addAttribute('a', 'data-trix-attachment', 'Text');
-        $def->addAttribute('a', 'data-trix-content-type', 'Text');
-        $def->addAttribute('a', 'data-trix-id', 'Number');
-        $def->addElement('span', 'Block', 'Flow', 'Common');
-        $def->addAttribute('span', 'data-trix-cursor-target', 'Enum#right,left');
-        $def->addAttribute('span', 'data-trix-serialize', 'Enum#true,false');
-        $def->addAttribute('img', 'data-trix-mutable', 'Enum#true,false');
-        $def->addAttribute('img', 'data-trix-store-key', 'Text');
+        $definition->addElement('figure', 'Inline', 'Inline', 'Common');
+        $definition->addAttribute('figure', 'class', 'Text');
+        $definition->addElement('figcaption', 'Inline', 'Inline', 'Common');
+        $definition->addAttribute('figcaption', 'class', 'Text');
+        $definition->addAttribute('figcaption', 'data-trix-placeholder', 'Text');
+        
+        $definition->addAttribute('a', 'rel', 'Text');
+        $definition->addAttribute('a', 'tabindex', 'Text');
+        $definition->addAttribute('a', 'contenteditable', 'Enum#true,false');
+        $definition->addAttribute('a', 'data-trix-attachment', 'Text');
+        $definition->addAttribute('a', 'data-trix-content-type', 'Text');
+        $definition->addAttribute('a', 'data-trix-id', 'Number');
+        
+        $definition->addElement('span', 'Block', 'Flow', 'Common');
+        $definition->addAttribute('span', 'data-trix-cursor-target', 'Enum#right,left');
+        $definition->addAttribute('span', 'data-trix-serialize', 'Enum#true,false');
+        
+        $definition->addAttribute('img', 'data-trix-mutable', 'Enum#true,false');
+        $definition->addAttribute('img', 'data-trix-store-key', 'Text');
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=7.1",
         "illuminate/support": "~5.5|~6.0|~7.0|~8.0|~9.0",
+        "illuminate/filesystem": "~5.5|~6.0|~7.0|~8.0|~9.0",
         "ezyang/htmlpurifier": "^4.9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=7.1",
         "illuminate/support": "~5.5|~6.0|~7.0|~8.0|~9.0",
-        "illuminate/filesystem": "~5.5|~6.0|~7.0|~8.0|~9.0",
         "ezyang/htmlpurifier": "^4.9.0"
     },
     "require-dev": {

--- a/config/purify.php
+++ b/config/purify.php
@@ -50,6 +50,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTMLPurifier definitions
+    |--------------------------------------------------------------------------
+    |
+    | Here you may alter the HTML definitions used by HTMLPurifier. You can
+    | add elements and attributes as needed. We've already added a few
+    | common examples.
+    |
+    | Note that these definitions are applied to every Purifier instance.
+    |
+    | Documentation: http://htmlpurifier.org/docs/enduser-customize.html
+    |
+    */
+
+    'definitions' => function(HTMLPurifier_HTMLDefinition $definition) {
+        $definition->addElement('u', 'Inline', 'Inline', 'Common');
+        $definition->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
+    },
+
+    /*
+    |--------------------------------------------------------------------------
     | Serializer location
     |--------------------------------------------------------------------------
     |
@@ -59,9 +79,6 @@ return [
     |
     */
 
-    'serializer' => [
-        'disk' => 'local',
-        'path' => storage_path('app/purify'),
-    ],
+    'serializer' => storage_path('app/purify'),
 
 ];

--- a/config/purify.php
+++ b/config/purify.php
@@ -50,15 +50,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cache location
+    | Serializer location
     |--------------------------------------------------------------------------
     |
-    | The location where HTMLPurifier can store its temporary cache files.
+    | The location where HTMLPurifier can store its temporary serializer files.
     | The filepath should be accessible and writable by the web server.
     | A good place for this is in the framework's own storage path.
     |
     */
 
-    'cache' => storage_path('app/purify'),
+    'serializer' => [
+        'disk' => 'local',
+        'path' => storage_path('app/purify'),
+    ],
 
 ];

--- a/config/purify.php
+++ b/config/purify.php
@@ -1,5 +1,7 @@
 <?php
 
+use Stevebauman\Purify\Definitions\Html5Definition;
+
 return [
 
     /*
@@ -38,7 +40,7 @@ return [
     'configs' => [
         'default' => [
             'Core.Encoding' => 'utf-8',
-            'HTML.Doctype' => 'XHTML 1.0 Strict',
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
             'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
             'HTML.ForbiddenElements' => '',
             'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
@@ -52,9 +54,11 @@ return [
     | HTMLPurifier definitions
     |--------------------------------------------------------------------------
     |
-    | Here you may alter the HTML definitions used by HTMLPurifier. You can
-    | add elements and attributes as needed. We've already added a few
-    | common examples.
+    | Here you may specify a class that augments the HTML definitions used by
+    | HTMLPurifier. Additional HTML5 definitions are provided out of the box.
+    | When specifying a custom class, make sure it implements the interface:
+    |
+    |   \Stevebauman\Purify\Definitions\Definition
     |
     | Note that these definitions are applied to every Purifier instance.
     |
@@ -62,22 +66,7 @@ return [
     |
     */
 
-    'definitions' => function(HTMLPurifier_HTMLDefinition $definition) {
-        $definition->addElement('u', 'Inline', 'Inline', 'Common');
-        $definition->addElement('s', 'Inline', 'Inline', 'Common');
-        $definition->addElement('var', 'Inline', 'Inline', 'Common');
-        $definition->addElement('mark', 'Inline', 'Inline', 'Common');
-        $definition->addElement('sub',  'Inline', 'Inline', 'Common');
-        $definition->addElement('sup',  'Inline', 'Inline', 'Common');
-        
-        $definition->addElement('ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
-        $definition->addElement('del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
-        $definition->addElement('address', 'Block', 'Flow', 'Common');
-        $definition->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
-        $definition->addElement('figcaption', 'Inline', 'Flow', 'Common');
-        
-        $definition->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
-    },
+    'definitions' => Html5Definition::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/purify.php
+++ b/config/purify.php
@@ -38,7 +38,6 @@ return [
     'configs' => [
         'default' => [
             'Core.Encoding' => 'utf-8',
-            'Cache.SerializerPath' => storage_path('app/purify'),
             'HTML.Doctype' => 'XHTML 1.0 Strict',
             'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
             'HTML.ForbiddenElements' => '',

--- a/config/purify.php
+++ b/config/purify.php
@@ -4,132 +4,61 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Settings
+    | Default Config
     |--------------------------------------------------------------------------
     |
-    | The configuration settings array is passed directly to HTMLPurifier.
-    |
-    | Feel free to add / remove / customize these attributes as you wish.
-    |
-    | Documentation: http://htmlpurifier.org/live/configdoc/plain.html
+    | This option defines the default config that are provided to HTMLPurifier.
     |
     */
 
-    'settings' => [
+    'default' => 'default',
 
-        /*
-        |--------------------------------------------------------------------------
-        | Core.Encoding
-        |--------------------------------------------------------------------------
-        |
-        | The encoding to convert input to.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#Core.Encoding
-        |
-        */
+    /*
+    |--------------------------------------------------------------------------
+    | Config sets
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure various sets of configuration for differentiated use of HTMLPurifier.
+    | A specific set of configuration can be applied by calling the "config($name)" method on
+    | a Purify instance. Feel free to add/remove/customize these attributes as you wish.
+    |
+    | Documentation: http://htmlpurifier.org/live/configdoc/plain.html
+    |
+    |   Core.Encoding               The encoding to convert input to.
+    |   HTML.Doctype                Doctype to use during filtering.
+    |   HTML.Allowed                The allowed HTML Elements with their allowed attributes.
+    |   HTML.ForbiddenElements      The forbidden HTML elements. Elements that are listed in this
+    |                               string will be removed, however their content will remain.
+    |   CSS.AllowedProperties       The Allowed CSS properties.
+    |   AutoFormat.AutoParagraph    Newlines are converted in to paragraphs whenever possible.
+    |   AutoFormat.RemoveEmpty      Remove empty elements that contribute no semantic information to the document.
+    |
+    */
 
-        'Core.Encoding' => 'utf-8',
-
-        /*
-        |--------------------------------------------------------------------------
-        | Core.SerializerPath
-        |--------------------------------------------------------------------------
-        |
-        | The HTML purifier serializer cache path.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#Cache.SerializerPath
-        |
-        */
-
-        'Cache.SerializerPath' => storage_path('app/purify'),
-
-        /*
-        |--------------------------------------------------------------------------
-        | HTML.Doctype
-        |--------------------------------------------------------------------------
-        |
-        | Doctype to use during filtering.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.Doctype
-        |
-        */
-
-        'HTML.Doctype' => 'XHTML 1.0 Strict',
-
-        /*
-        |--------------------------------------------------------------------------
-        | HTML.Allowed
-        |--------------------------------------------------------------------------
-        |
-        | The allowed HTML Elements with their allowed attributes.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.Allowed
-        |
-        */
-
-        'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
-
-        /*
-        |--------------------------------------------------------------------------
-        | HTML.ForbiddenElements
-        |--------------------------------------------------------------------------
-        |
-        | The forbidden HTML elements. Elements that are listed in
-        | this string will be removed, however their content will remain.
-        |
-        | For example if 'p' is inside the string, the string: '<p>Test</p>',
-        |
-        | Will be cleaned to: 'Test'
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#HTML.ForbiddenElements
-        |
-        */
-
-        'HTML.ForbiddenElements' => '',
-
-        /*
-        |--------------------------------------------------------------------------
-        | CSS.AllowedProperties
-        |--------------------------------------------------------------------------
-        |
-        | The Allowed CSS properties.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#CSS.AllowedProperties
-        |
-        */
-
-        'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
-
-        /*
-        |--------------------------------------------------------------------------
-        | AutoFormat.AutoParagraph
-        |--------------------------------------------------------------------------
-        |
-        | The Allowed CSS properties.
-        |
-        | This directive turns on auto-paragraphing, where double
-        | newlines are converted in to paragraphs whenever possible.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#AutoFormat.AutoParagraph
-        |
-        */
-
-        'AutoFormat.AutoParagraph' => false,
-
-        /*
-        |--------------------------------------------------------------------------
-        | AutoFormat.RemoveEmpty
-        |--------------------------------------------------------------------------
-        |
-        | When enabled, HTML Purifier will attempt to remove empty
-        | elements that contribute no semantic information to the document.
-        |
-        | http://htmlpurifier.org/live/configdoc/plain.html#AutoFormat.RemoveEmpty
-        |
-        */
-
-        'AutoFormat.RemoveEmpty' => false,
-
+    'configs' => [
+        'default' => [
+            'Core.Encoding' => 'utf-8',
+            'Cache.SerializerPath' => storage_path('app/purify'),
+            'HTML.Doctype' => 'XHTML 1.0 Strict',
+            'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
+            'HTML.ForbiddenElements' => '',
+            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'AutoFormat.AutoParagraph' => false,
+            'AutoFormat.RemoveEmpty' => false,
+        ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache location
+    |--------------------------------------------------------------------------
+    |
+    | The location where HTMLPurifier can store its temporary cache files.
+    | The filepath should be accessible and writable by the web server.
+    | A good place for this is in the framework's own storage path.
+    |
+    */
+
+    'cache' => storage_path('app/purify'),
 
 ];

--- a/config/purify.php
+++ b/config/purify.php
@@ -64,6 +64,18 @@ return [
 
     'definitions' => function(HTMLPurifier_HTMLDefinition $definition) {
         $definition->addElement('u', 'Inline', 'Inline', 'Common');
+        $definition->addElement('s', 'Inline', 'Inline', 'Common');
+        $definition->addElement('var', 'Inline', 'Inline', 'Common');
+        $definition->addElement('mark', 'Inline', 'Inline', 'Common');
+        $definition->addElement('sub',  'Inline', 'Inline', 'Common');
+        $definition->addElement('sup',  'Inline', 'Inline', 'Common');
+        
+        $definition->addElement('ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
+        $definition->addElement('del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
+        $definition->addElement('address', 'Block', 'Flow', 'Common');
+        $definition->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+        $definition->addElement('figcaption', 'Inline', 'Flow', 'Common');
+        
         $definition->addAttribute('a', 'target', 'Enum#_blank,_self,_target,_top');
     },
 

--- a/src/Definitions/Definition.php
+++ b/src/Definitions/Definition.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stevebauman\Purify\Definitions;
+
+use HTMLPurifier_HTMLDefinition;
+
+interface Definition
+{
+    public static function apply(HTMLPurifier_HTMLDefinition $definition);
+}

--- a/src/Definitions/Html5Definition.php
+++ b/src/Definitions/Html5Definition.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Stevebauman\Purify\Definitions;
+
+use HTMLPurifier_HTMLDefinition;
+
+class Html5Definition implements Definition
+{
+    public static function apply(HTMLPurifier_HTMLDefinition $definition)
+    {
+        // http://developers.whatwg.org/sections.html
+        $definition->addElement('section', 'Block', 'Flow', 'Common');
+        $definition->addElement('nav', 'Block', 'Flow', 'Common');
+        $definition->addElement('article', 'Block', 'Flow', 'Common');
+        $definition->addElement('aside', 'Block', 'Flow', 'Common');
+        $definition->addElement('header', 'Block', 'Flow', 'Common');
+        $definition->addElement('footer', 'Block', 'Flow', 'Common');
+        $definition->addElement('address', 'Block', 'Flow', 'Common');
+        $definition->addElement('hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common');
+
+        // http://developers.whatwg.org/grouping-content.html
+        $definition->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+        $definition->addElement('figcaption', 'Inline', 'Flow', 'Common');
+
+        // http://developers.whatwg.org/the-video-element.html#the-video-element
+        $definition->addElement('video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+            'src' => 'URI',
+            'type' => 'Text',
+            'width' => 'Length',
+            'height' => 'Length',
+            'poster' => 'URI',
+            'preload' => 'Enum#auto,metadata,none',
+            'controls' => 'Bool',
+        ]);
+        $definition->addElement('source', 'Block', 'Flow', 'Common', [
+            'src' => 'URI',
+            'type' => 'Text',
+        ]);
+
+        // http://developers.whatwg.org/text-level-semantics.html
+        $definition->addElement('u', 'Inline', 'Inline', 'Common');
+        $definition->addElement('s', 'Inline', 'Inline', 'Common');
+        $definition->addElement('var', 'Inline', 'Inline', 'Common');
+        $definition->addElement('sub', 'Inline', 'Inline', 'Common');
+        $definition->addElement('sup', 'Inline', 'Inline', 'Common');
+        $definition->addElement('mark', 'Inline', 'Inline', 'Common');
+        $definition->addElement('wbr', 'Inline', 'Empty', 'Core');
+
+        // http://developers.whatwg.org/edits.html
+        $definition->addElement('ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
+        $definition->addElement('del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']);
+
+        $definition->addAttribute('table', 'height', 'Text');
+        $definition->addAttribute('td', 'border', 'Text');
+        $definition->addAttribute('th', 'border', 'Text');
+        $definition->addAttribute('tr', 'width', 'Text');
+        $definition->addAttribute('tr', 'height', 'Text');
+        $definition->addAttribute('tr', 'border', 'Text');
+    }
+}

--- a/src/Purify.php
+++ b/src/Purify.php
@@ -9,11 +9,6 @@ use Illuminate\Filesystem\Filesystem;
 class Purify
 {
     /**
-     * @var Filesystem
-     */
-    protected $files;
-
-    /**
      * The HTML Purifier instance.
      *
      * @var HTMLPurifier
@@ -25,13 +20,9 @@ class Purify
      *
      * @param array $config
      */
-    public function __construct(Filesystem $files, array $config)
+    public function __construct(HTMLPurifier_Config $config)
     {
-        $this->files = $files;
-
-        $this->purifier = new HTMLPurifier(
-            HTMLPurifier_Config::create($config)
-        );
+        $this->purifier = new HTMLPurifier($config);
     }
 
     /**
@@ -43,19 +34,8 @@ class Purify
      */
     public function clean($input)
     {
-        $this->ensureCacheSerializePathExists();
-
         return is_array($input)
             ? $this->purifier->purifyArray($input)
             : $this->purifier->purify($input);
-    }
-
-    protected function ensureCacheSerializePathExists()
-    {
-        $path = $this->purifier->config->get('Cache.SerializerPath');
-
-        if (! $this->files->exists($path)) {
-            $this->files->makeDirectory($path);
-        }
     }
 }

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Stevebauman\Purify;
+
+use Illuminate\Support\Manager;
+use InvalidArgumentException;
+
+class PurifyManager extends Manager
+{
+    /**
+     * Convenience alias for driver().
+     *
+     * @param string|array|null $config
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function config($config = null)
+    {
+        return $this->driver($config);
+    }
+
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return $this->config->get('purify.default');
+    }
+
+    /**
+     * Get a driver instance.
+     *
+     * @param string|array|null $driver
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function driver($driver = null)
+    {
+        // First, we will check if the provided "driver" is an array.
+        // If so, we're dealing with inline defined config.
+        if (is_array($driver)) {
+            $config = $driver;
+            $driver = md5(serialize($driver));
+
+            $this->config->set('purify.configs.' . $driver, $config);
+        }
+
+        return parent::driver($driver);
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param string|array $driver
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function createDriver($driver)
+    {
+        // First, we will determine if a custom driver creator exists for the given driver and
+        // if it does not we will check for a creator method for the driver. Custom creator
+        // callbacks allow developers to build their own "drivers" easily using Closures.
+        if (isset($this->customCreators[$driver])) {
+            return $this->callCustomCreator($driver);
+        }
+
+        if ($config = $this->resolveConfig($driver)) {
+            return $this->createInstance($driver, $config);
+        }
+
+        throw new InvalidArgumentException("Purify config [$driver] not defined.");
+    }
+
+    /**
+     * Resolve the configuration for the given config name.
+     *
+     * @param string $name
+     * @return array
+     */
+    protected function resolveConfig($name)
+    {
+        return $this->config->get("purify.configs.{$name}");
+    }
+
+    /**
+     * Create a new Purify instance with the given config.
+     *
+     * @param string $name
+     * @param array $config
+     * @return Purify
+     */
+    protected function createInstance(string $name, array $config)
+    {
+        return new Purify(
+            $this->container->make('files'),
+            array_merge([
+                'Cache.SerializerPath' => $this->config->get('purify.cache') . DIRECTORY_SEPARATOR . $name,
+            ], $config)
+        );
+    }
+}

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -2,6 +2,7 @@
 
 namespace Stevebauman\Purify;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
 
@@ -27,7 +28,7 @@ class PurifyManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->config->get('purify.default');
+        return $this->container->make('config')->get('purify.default');
     }
 
     /**
@@ -46,7 +47,7 @@ class PurifyManager extends Manager
             $config = $driver;
             $driver = md5(serialize($driver));
 
-            $this->config->set("purify.configs.{$driver}", $config);
+            $this->container->make('config')->set("purify.configs.{$driver}", $config);
         }
 
         return parent::driver($driver);
@@ -84,7 +85,7 @@ class PurifyManager extends Manager
      */
     protected function resolveConfig($name)
     {
-        return $this->config->get("purify.configs.{$name}");
+        return $this->container->make('config')->get("purify.configs.{$name}");
     }
 
     /**
@@ -97,10 +98,10 @@ class PurifyManager extends Manager
     protected function createInstance(string $name, array $config)
     {
         $filesystem = $this->container->make('filesystem')->disk(
-            $this->config->get('purify.serializer.disk', 'local')
+            $this->container->make('config')->get('purify.serializer.disk', 'local')
         );
 
-        $path = $this->config->get('purify.serializer.path') . DIRECTORY_SEPARATOR . $name;
+        $path = $this->container->make('config')->get('purify.serializer.path') . DIRECTORY_SEPARATOR . $name;
 
         return new Purify($filesystem, array_merge([
             'Cache.SerializerPath' => $path,

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -3,10 +3,9 @@
 namespace Stevebauman\Purify;
 
 use HTMLPurifier_Config;
-use Illuminate\Contracts\Container\Container;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
+use Stevebauman\Purify\Definitions\Definition;
 
 class PurifyManager extends Manager
 {
@@ -129,8 +128,10 @@ class PurifyManager extends Manager
         $htmlConfig->set('HTML.DefinitionRev', 1);
 
         if ($definition = $htmlConfig->maybeGetRawHTMLDefinition()) {
-            if (is_callable($callback = $this->container->make('config')->get('purify.definitions'))) {
-                call_user_func($callback, $definition);
+            $definitionsClass = $this->container->make('config')->get('purify.definitions');
+
+            if ($definitionsClass && is_a($definitionsClass, Definition::class, true)) {
+                $definitionsClass::apply($definition);
             }
         }
 

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -46,7 +46,7 @@ class PurifyManager extends Manager
             $config = $driver;
             $driver = md5(serialize($driver));
 
-            $this->config->set('purify.configs.' . $driver, $config);
+            $this->config->set("purify.configs.{$driver}", $config);
         }
 
         return parent::driver($driver);

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -96,11 +96,14 @@ class PurifyManager extends Manager
      */
     protected function createInstance(string $name, array $config)
     {
-        return new Purify(
-            $this->container->make('files'),
-            array_merge([
-                'Cache.SerializerPath' => $this->config->get('purify.cache') . DIRECTORY_SEPARATOR . $name,
-            ], $config)
+        $filesystem = $this->container->make('filesystem')->disk(
+            $this->config->get('purify.serializer.disk', 'local')
         );
+
+        $path = $this->config->get('purify.serializer.path') . DIRECTORY_SEPARATOR . $name;
+
+        return new Purify($filesystem, array_merge([
+            'Cache.SerializerPath' => $path,
+        ], $config));
     }
 }

--- a/src/PurifyServiceProvider.php
+++ b/src/PurifyServiceProvider.php
@@ -18,10 +18,10 @@ class PurifyServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/purify.php', 'purify');
+
         $this->app->singleton('purify', function ($app) {
-            return new Purify(
-                $app['config']['purify.settings'] ?? $this->getDefaultPurifierConfig()
-            );
+            return new PurifyManager($app);
         });
     }
 
@@ -35,35 +35,10 @@ class PurifyServiceProvider extends ServiceProvider
         if ($this->app instanceof Laravel && $this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../config/purify.php' => config_path('purify.php'),
-                $this->getDefaultPurifierDefinitionCacheDirectory() => storage_path('app/purify'),
             ], 'config');
         } elseif ($this->app instanceof Lumen) {
             $this->app->configure('purify');
         }
-    }
-
-    /**
-     * Get the default HTML Purifier definition cache directory.
-     *
-     * @return string
-     */
-    protected function getDefaultPurifierDefinitionCacheDirectory()
-    {
-        $defaultConfig = HTMLPurifier_Config::create($this->getDefaultPurifierConfig());
-
-        $serializer = new HTMLPurifier_DefinitionCache_Serializer(null);
-
-        return $serializer->generateBaseDirectoryPath($defaultConfig);
-    }
-
-    /**
-     * Get the default HTML Purifier configuration.
-     *
-     * @return array
-     */
-    protected function getDefaultPurifierConfig()
-    {
-        return HTMLPurifier_ConfigSchema::instance()->defaults;
     }
 
     /**

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -11,12 +11,11 @@ class PurifyTest extends TestCase
 {
     public $testInput = '<script>alert("Harmful Script");</script><p style="a {color: #0000ff;}" class="a-different-class">Test</p>';
 
-    public function test_configuration_file_is_published_and_storage_directory_exists()
+    public function test_configuration_file_is_published()
     {
         $this->artisan('vendor:publish', ['--provider' => PurifyServiceProvider::class]);
 
         $this->assertFileExists(config_path('purify.php'));
-        $this->assertDirectoryExists(storage_path('app/purify'));
 
         File::delete(config_path('purify.php'));
         File::deleteDirectory(storage_path('app/purify'));
@@ -26,7 +25,7 @@ class PurifyTest extends TestCase
     {
         $cleaned = Purify::clean($this->testInput);
 
-        $expected = '<p class="a-different-class">Test</p>';
+        $expected = '<p>Test</p>';
 
         $this->assertEquals($expected, $cleaned);
     }
@@ -35,37 +34,69 @@ class PurifyTest extends TestCase
     {
         $cleaned = Purify::clean([$this->testInput, $this->testInput]);
 
-        $expected = ['<p class="a-different-class">Test</p>', '<p class="a-different-class">Test</p>'];
+        $expected = ['<p>Test</p>', '<p>Test</p>'];
 
         $this->assertEquals($expected, $cleaned);
     }
 
-    public function test_given_config_overwrites_default_config()
+    public function test_config_alias_is_available()
+    {
+        $instance = Purify::config();
+
+        $this->assertInstanceOf(\Stevebauman\Purify\Purify::class, $instance);
+    }
+
+    public function test_config_set_can_be_chosen()
     {
         $input = '<a href="http://www.google.ca">Google</a>';
 
-        $cleaned = Purify::clean($input);
+        $this->app['config']->set('purify.configs.foo', [
+            'HTML.TargetBlank' => true
+        ]);
 
-        $this->assertEquals($cleaned, $input);
-
-        $settings = ['HTML.TargetBlank' => true];
-
-        $cleanedTargetBlank = Purify::clean($input, $settings);
+        $cleaned = Purify::driver('foo')->clean($input);
 
         $expected = '<a href="http://www.google.ca" target="_blank" rel="noreferrer noopener">Google</a>';
 
-        $this->assertEquals($expected, $cleanedTargetBlank);
+        $this->assertEquals($expected, $cleaned);
     }
 
-    public function test_purifier_instance_is_accessible()
+    public function test_config_can_be_provided_inline()
     {
-        $this->assertInstanceOf(HTMLPurifier::class, Purify::getPurifier());
+        $input = '<a href="http://www.google.ca">Google</a>';
+
+        $cleaned = Purify::config([
+            'HTML.TargetBlank' => true
+        ])->clean($input);
+
+        $expected = '<a href="http://www.google.ca" target="_blank" rel="noreferrer noopener">Google</a>';
+
+        $this->assertEquals($expected, $cleaned);
     }
 
-    public function test_purifier_instance_can_be_set()
+    public function test_configs_are_independent()
     {
-        $purifier = new HTMLPurifier();
+        $input = '<a href="http://www.google.ca">Google</a>';
 
-        $this->assertInstanceOf(HTMLPurifier::class, Purify::setPurifier($purifier)->getPurifier());
+        $this->app['config']->set('purify.configs.foo', [
+            'HTML.TargetBlank' => true,
+        ]);
+
+        $this->app['config']->set('purify.configs.bar', [
+            'HTML.TargetBlank' => true,
+            'HTML.TargetNoopener' => false,
+        ]);
+
+        $cleaned1 = Purify::driver()->clean($input);
+        $cleaned2 = Purify::driver('foo')->clean($input);
+        $cleaned3 = Purify::driver('bar')->clean($input);
+
+        $expected1 = '<a href="http://www.google.ca">Google</a>';
+        $expected2 = '<a href="http://www.google.ca" target="_blank" rel="noreferrer noopener">Google</a>';
+        $expected3 = '<a href="http://www.google.ca" target="_blank" rel="noreferrer">Google</a>';
+
+        $this->assertEquals($expected1, $cleaned1);
+        $this->assertEquals($expected2, $cleaned2);
+        $this->assertEquals($expected3, $cleaned3);
     }
 }

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -2,9 +2,9 @@
 
 namespace Stevebauman\Purify\Tests;
 
-use HTMLPurifier;
 use HTMLPurifier_HTMLDefinition;
 use Illuminate\Support\Facades\File;
+use Stevebauman\Purify\Definitions\Definition;
 use Stevebauman\Purify\Facades\Purify;
 use Stevebauman\Purify\PurifyServiceProvider;
 
@@ -103,9 +103,7 @@ class PurifyTest extends TestCase
 
     public function test_definitions_are_applied()
     {
-        $this->app['config']->set('purify.definitions', function(HTMLPurifier_HTMLDefinition $definition) {
-            $definition->addElement('foo', 'Inline', 'Inline', 'Common');
-        });
+        $this->app['config']->set('purify.definitions', FooDefinition::class);
 
         $input = '<foo>Test</foo>';
 
@@ -119,5 +117,13 @@ class PurifyTest extends TestCase
 
         $this->assertEquals($expected1, $cleaned1);
         $this->assertEquals($expected2, $cleaned2);
+    }
+}
+
+class FooDefinition implements Definition
+{
+    public static function apply(HTMLPurifier_HTMLDefinition $definition)
+    {
+        $definition->addElement('foo', 'Inline', 'Inline', 'Common');
     }
 }

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -3,6 +3,7 @@
 namespace Stevebauman\Purify\Tests;
 
 use HTMLPurifier;
+use HTMLPurifier_HTMLDefinition;
 use Illuminate\Support\Facades\File;
 use Stevebauman\Purify\Facades\Purify;
 use Stevebauman\Purify\PurifyServiceProvider;
@@ -98,5 +99,25 @@ class PurifyTest extends TestCase
         $this->assertEquals($expected1, $cleaned1);
         $this->assertEquals($expected2, $cleaned2);
         $this->assertEquals($expected3, $cleaned3);
+    }
+
+    public function test_definitions_are_applied()
+    {
+        $this->app['config']->set('purify.definitions', function(HTMLPurifier_HTMLDefinition $definition) {
+            $definition->addElement('foo', 'Inline', 'Inline', 'Common');
+        });
+
+        $input = '<foo>Test</foo>';
+
+        $cleaned1 = Purify::driver()->clean($input);
+        $cleaned2 = Purify::config([
+            'HTML.Allowed' => 'foo',
+        ])->clean($input);
+
+        $expected1 = 'Test';
+        $expected2 = '<foo>Test</foo>';
+
+        $this->assertEquals($expected1, $cleaned1);
+        $this->assertEquals($expected2, $cleaned2);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Stevebauman\Purify\Tests;
 
 use Stevebauman\Purify\Facades\Purify;
+use Stevebauman\Purify\PurifyManager;
 use Stevebauman\Purify\PurifyServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -10,7 +11,7 @@ class TestCase extends BaseTestCase
 {
     protected function getPackageAliases($app)
     {
-        return ['Purify' => Purify::class];
+        return ['Purify' => PurifyManager::class];
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Hi

This rather unsollicited PR enables the use of multiple configurations for HTMLPurifier. Just like other first-party components (logging, mail, database, ...).

It makes use of Illuminate's built-in `Manager` class.
I've removed a couple of methods as I'm convinced that they are no more useful in this context.

I think the config file's new format explains the entire PR.

Note: I didn't implement legacy support.