### PR TITLE
Add Eloquent casts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,26 +14,16 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.1, 8.0, 7.4, 7.3]
-                laravel: [8.*, 7.*, 6.*, 5.8.*]
+                laravel: [8.*, 7.*]
                 dependency-version: [prefer-stable]
                 include:
                     - laravel: 8.*
                       testbench: 6.*
                     - laravel: 7.*
                       testbench: 5.*
-                    - laravel: 6.*
-                      testbench: 4.*
-                    - laravel: 5.8.*
-                      testbench: 3.8.*
                 exclude:
                     - laravel: 7.*
                       php: 8.1
-                    - laravel: 6.*
-                      php: 8.1
-                    - laravel: 5.8.*
-                      php: 8.1
-                    - laravel: 5.8.*
-                      php: 8.0
 
         name: ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ $config = ['HTML.Allowed' => 'div,b,a[href]'];
 $cleaned = Purify::config($config)->clean($input);
 ```
 
+### Configuration
+
+Inside the configuration file, multiple HTMLPurifier configuration sets
+can be specified, similar to Laravel's built-in `database`, `mail` and `logging` config.
+Simply call `Purify::config($name)->clean($input)` to use another set of configuration.
+
+For HTMLPurifier configuration documentation, please visit the HTMLPurifier Website:
+
+http://htmlpurifier.org/live/configdoc/plain.html
+
 ### Practices
 
 If you're looking into sanitization, you're likely wanting to sanitize inputted user HTML content
@@ -88,18 +98,30 @@ Remember, the **database doesn't care what text it contains**.
 
 This way you can allow anything to be inserted in the database, and have strong sanization rules on the way out.
 
+To accomplish this you may use the provided `PurifyHtmlOnGet` cast class on your Eloquent model:
+
+```php
+use Stevebauman\Purify\Casts\PurifyHtmlOnGet;
+
+class MyModel extens Model
+{
+    protected $casts = [
+        'my_column' => PurifyHtmlOnGet::class,
+    ];
+}
+```
+
+You can even configure the configuration set used when casting:
+```php
+protected $casts = [
+    'my_column' => PurifyHtmlOnGet::class.':my_custom_set',
+];
+```
+
 This helps tremendously if you change your sanization requirements later down the line,
 then all rendered content will follow these sanization rules.
 
-### Configuration
-
-Inside the configuration file, multiple HTMLPurifier configuration sets
-can be specified, similar to Laravel's built-in `database`, `mail` and `logging` config.
-Simply call `Purify::config($name)->clean($input)` to use another set of configuration.
-
-For HTMLPurifier configuration documentation, please visit the HTMLPurifier Website:
-
-http://htmlpurifier.org/live/configdoc/plain.html
+If you'd like to purify HTML while setting the value, you can use the inverse `PurifyHtmlOnSet` cast instead.
 
 #### Custom HTML definitions
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     "license" : "MIT",
     "require": {
         "php": ">=7.1",
-        "illuminate/support": "~5.5|~6.0|~7.0|~8.0|~9.0",
-        "ezyang/htmlpurifier": "^4.9.0"
+        "ezyang/htmlpurifier": "^4.9.0",
+        "illuminate/contracts": "~7.0|~8.0|~9.0",
+        "illuminate/support": "~7.0|~8.0|~9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0|~8.0|~9.0",
-        "orchestra/testbench": "~3.7|~4.0|~5.0|~6.0|~7.0"
+        "phpunit/phpunit": "~8.0|~9.0",
+        "orchestra/testbench": "~5.0|~6.0|~7.0"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/src/Casts/PurifyHtmlOnGet.php
+++ b/src/Casts/PurifyHtmlOnGet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stevebauman\Purify\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Stevebauman\Purify\Facades\Purify;
+
+class PurifyHtmlOnGet implements CastsAttributes
+{
+    protected $config = null;
+
+    public function __construct($config = null)
+    {
+        $this->config = $config;
+    }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return Purify::config($this->config)->clean($value);
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+}

--- a/src/Casts/PurifyHtmlOnSet.php
+++ b/src/Casts/PurifyHtmlOnSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stevebauman\Purify\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Stevebauman\Purify\Facades\Purify;
+
+class PurifyHtmlOnSet implements CastsAttributes
+{
+    protected $config = null;
+
+    public function __construct($config = null)
+    {
+        $this->config = $config;
+    }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return Purify::config($this->config)->clean($value);
+    }
+}

--- a/tests/CastsTest.php
+++ b/tests/CastsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Stevebauman\Purify\Tests;
+
+use HTMLPurifier_HTMLDefinition;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+use Stevebauman\Purify\Casts\PurifyHtmlOnGet;
+use Stevebauman\Purify\Casts\PurifyHtmlOnSet;
+use Stevebauman\Purify\Definitions\Definition;
+use Stevebauman\Purify\Facades\Purify;
+use Stevebauman\Purify\PurifyServiceProvider;
+
+class CastsTest extends TestCase
+{
+    public $testInput = '<script>alert("Harmful Script");</script><p style="a {color: #0000ff;}" class="a-different-class">Test<span>bar</span></p>';
+
+    public function test_purifies_on_get_with_default_config()
+    {
+        $this->app['config']->set('purify.configs.default', [
+            'HTML.Allowed' => 'p',
+        ]);
+
+        $model = new PurifyingDefaultOnGetModel();
+        $model->body = $this->testInput;
+
+        $this->assertEquals($this->testInput, $model->getAttributes()['body']);
+        $this->assertEquals('<p>Testbar</p>', $model->body);
+    }
+
+    public function test_purifies_on_get_with_custom_config()
+    {
+        $this->app['config']->set('purify.configs.foo', [
+            'HTML.Allowed' => 'p,span',
+        ]);
+
+        $model = new PurifyingFooOnGetModel();
+        $model->body = $this->testInput;
+
+        $this->assertEquals($this->testInput, $model->getAttributes()['body']);
+        $this->assertEquals('<p>Test<span>bar</span></p>', $model->body);
+    }
+
+    public function test_purifies_on_set_with_default_config()
+    {
+        $this->app['config']->set('purify.configs.default', [
+            'HTML.Allowed' => 'p',
+        ]);
+
+        $model = new PurifyingDefaultOnSetModel();
+        $model->body = $this->testInput;
+
+        $this->assertEquals('<p>Testbar</p>', $model->getAttributes()['body']);
+    }
+
+    public function test_purifies_on_set_with_custom_config()
+    {
+        $this->app['config']->set('purify.configs.foo', [
+            'HTML.Allowed' => 'p,span',
+        ]);
+
+        $model = new PurifyingFooOnSetModel();
+        $model->body = $this->testInput;
+
+        $this->assertEquals('<p>Test<span>bar</span></p>', $model->getAttributes()['body']);
+    }
+}
+
+class PurifyingDefaultOnGetModel extends Model
+{
+    protected $casts = [
+        'body' => PurifyHtmlOnGet::class,
+    ];
+}
+
+class PurifyingFooOnGetModel extends Model
+{
+    protected $casts = [
+        'body' => PurifyHtmlOnGet::class.':foo',
+    ];
+}
+
+
+class PurifyingDefaultOnSetModel extends Model
+{
+    protected $casts = [
+        'body' => PurifyHtmlOnSet::class,
+    ];
+}
+
+class PurifyingFooOnSetModel extends Model
+{
+    protected $casts = [
+        'body' => PurifyHtmlOnSet::class.':foo',
+    ];
+}
+


### PR DESCRIPTION
Here's another PR implementing Eloquent cast classes, supporting the newly introduced config sets as well.

Note that custom cast classes were implemented as of Laravel 7, so I've dropped support below that version. 

Note2: the GitHub actions workflow doesn't check Laravel 9?