### PR TITLE
Added strikethrough elements to default allow list

### DIFF
--- a/config/purify.php
+++ b/config/purify.php
@@ -42,7 +42,7 @@ return [
         'default' => [
             'Core.Encoding' => 'utf-8',
             'HTML.Doctype' => 'HTML 4.01 Transitional',
-            'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
+            'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,strong,i,em,s,del,a[href|title],ul,ol,li,p[style],br,span,img[width|height|alt|src]',
             'HTML.ForbiddenElements' => '',
             'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
             'AutoFormat.AutoParagraph' => false,


### PR DESCRIPTION
👋 Hey Steve,

Firstly, thanks for the package. Works great and is very useful! 

I'm implementing a WYSIWYG editor using Trix and noticed that elements for strikethrough text (`s` and `del`) are not in the default list. Obviously, I can publish the config file and change this, but it seemed like something you might want in the default set of tags.
