### PR TITLE
Handle null values correctly in casts

### DIFF
--- a/src/Casts/PurifyHtmlOnGet.php
+++ b/src/Casts/PurifyHtmlOnGet.php
@@ -15,7 +15,7 @@ class PurifyHtmlOnGet extends Caster implements CastsAttributes
      * @param mixed                               $value
      * @param array                               $attributes
      *
-     * @return string|array
+     * @return string|array|null
      */
     public function get($model, $key, $value, $attributes)
     {
@@ -34,7 +34,7 @@ class PurifyHtmlOnGet extends Caster implements CastsAttributes
      * @param mixed                               $value
      * @param array                               $attributes
      *
-     * @return array|string
+     * @return array|string|null
      */
     public function set($model, $key, $value, $attributes)
     {

--- a/src/Casts/PurifyHtmlOnGet.php
+++ b/src/Casts/PurifyHtmlOnGet.php
@@ -19,6 +19,10 @@ class PurifyHtmlOnGet extends Caster implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
+        if (is_null($value)) {
+            return null;    
+        }
+        
         return Purify::config($this->config)->clean($value);
     }
 

--- a/src/Casts/PurifyHtmlOnGet.php
+++ b/src/Casts/PurifyHtmlOnGet.php
@@ -20,9 +20,9 @@ class PurifyHtmlOnGet extends Caster implements CastsAttributes
     public function get($model, $key, $value, $attributes)
     {
         if (is_null($value)) {
-            return null;    
+            return null;
         }
-        
+
         return Purify::config($this->config)->clean($value);
     }
 

--- a/src/Casts/PurifyHtmlOnSet.php
+++ b/src/Casts/PurifyHtmlOnSet.php
@@ -35,9 +35,9 @@ class PurifyHtmlOnSet extends Caster implements CastsAttributes
     public function set($model, string $key, $value, array $attributes)
     {
         if (is_null($value)) {
-            return null;    
+            return null;
         }
-        
+
         return Purify::config($this->config)->clean($value);
     }
 }

--- a/src/Casts/PurifyHtmlOnSet.php
+++ b/src/Casts/PurifyHtmlOnSet.php
@@ -15,7 +15,7 @@ class PurifyHtmlOnSet extends Caster implements CastsAttributes
      * @param mixed                               $value
      * @param array                               $attributes
      *
-     * @return string|array
+     * @return string|array|null
      */
     public function get($model, string $key, $value, array $attributes)
     {
@@ -30,10 +30,14 @@ class PurifyHtmlOnSet extends Caster implements CastsAttributes
      * @param mixed                               $value
      * @param array                               $attributes
      *
-     * @return array|string
+     * @return array|string|null
      */
     public function set($model, string $key, $value, array $attributes)
     {
+        if (is_null($value)) {
+            return null;    
+        }
+        
         return Purify::config($this->config)->clean($value);
     }
 }

--- a/tests/CastsTest.php
+++ b/tests/CastsTest.php
@@ -35,6 +35,14 @@ class CastsTest extends TestCase
         $this->assertEquals($this->testInput, $model->getAttributes()['body']);
         $this->assertEquals('<p>Test<span>bar</span></p>', $model->body);
     }
+    
+    public function test_returns_null_on_get_when_value_is_null()
+    {
+        $model = new PurifyingDefaultOnGetModel();
+        $model->body = null;
+
+        $this->assertNull($model->body);
+    }
 
     public function test_purifies_on_set_with_default_config()
     {
@@ -58,6 +66,14 @@ class CastsTest extends TestCase
         $model->body = $this->testInput;
 
         $this->assertEquals('<p>Test<span>bar</span></p>', $model->getAttributes()['body']);
+    }
+    
+    public function test_sets_null_on_set_when_value_is_null()
+    {
+        $model = new PurifyingDefaultOnSetModel();
+        $model->body = null;
+
+        $this->assertNull($model->getAttributes()['body']);
     }
 }
 

--- a/tests/CastsTest.php
+++ b/tests/CastsTest.php
@@ -35,7 +35,7 @@ class CastsTest extends TestCase
         $this->assertEquals($this->testInput, $model->getAttributes()['body']);
         $this->assertEquals('<p>Test<span>bar</span></p>', $model->body);
     }
-    
+
     public function test_returns_null_on_get_when_value_is_null()
     {
         $model = new PurifyingDefaultOnGetModel();
@@ -67,7 +67,7 @@ class CastsTest extends TestCase
 
         $this->assertEquals('<p>Test<span>bar</span></p>', $model->getAttributes()['body']);
     }
-    
+
     public function test_sets_null_on_set_when_value_is_null()
     {
         $model = new PurifyingDefaultOnSetModel();


### PR DESCRIPTION
At this moment the casts will always purify the value. As a side effect `null` values get "purified" to empty strings `""`.
Let's keep them as `null`...