### PR TITLE
Add custom CSS Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,15 +352,15 @@ inline styles you allow and their properties and values. This can help fill in
 missing values for properties such as text-align, which by default is missing start
 and end values. You can do this by creating a CSS definition.
 
-To create your own CSS definition, create a new class and have it implement `CSSDefinition`:
+To create your own CSS definition, create a new class and have it implement `CssDefinition`:
 
 ```php
 namespace App;
 
 use HTMLPurifier_CSSDefinition;
-use Stevebauman\Purify\Definitions\CSSDefinition;
+use Stevebauman\Purify\Definitions\CssDefinition;
 
-class CustomCSSDefinition implements CSSDefinition
+class CustomCSSDefinition implements CssDefinition
 {
     /**
      * Apply rules to the CSS Purifier definition.
@@ -385,7 +385,7 @@ Then, reference this class in the `config/purify.php` file in the `css-definitio
 ```php
 // config/purify.php
 
-'css-definitions' => \App\CustomCSSDefinition::class,
+'css-definitions' => \App\CustomCssDefinition::class,
 ```
 
 See the class HTMLPurifier_CSSDefinition in the HTMLPurifier library for other examples of what can be changed.

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ class CustomCSSDefinition implements CSSDefinition
     {
         // Customize the CSS purifier definition.
         $definition->info['text-align'] = new \HTMLPurifier_AttrDef_Enum(
-            array('right', 'left', 'center', 'start', 'end'),
+            ['right', 'left', 'center', 'start', 'end'],
             false,
         );
     }

--- a/README.md
+++ b/README.md
@@ -344,6 +344,52 @@ class TrixPurifierDefinitions implements Definition
 }
 ```
 
+
+#### Custom CSS definitions
+
+It's possible to override the CSS definitions, this allows you to customize what
+inline styles you allow and their properties and values. This can help fill in
+missing values for properties such as text-align, which by default is missing start
+and end values. You can do this by creating a CSS definition.
+
+To create your own CSS definition, create a new class and have it implement `CSSDefinition`:
+
+```php
+namespace App;
+
+use HTMLPurifier_CSSDefinition;
+use Stevebauman\Purify\Definitions\CSSDefinition;
+
+class CustomCSSDefinition implements CSSDefinition
+{
+    /**
+     * Apply rules to the CSS Purifier definition.
+     *
+     * @param HTMLPurifier_CSSDefinition $definition
+     *
+     * @return void
+     */
+    public static function apply(HTMLPurifier_CSSDefinition $definition)
+    {
+        // Customize the CSS purifier definition.
+        $definition->info['text-align'] = new \HTMLPurifier_AttrDef_Enum(
+            array('right', 'left', 'center', 'start', 'end'),
+            false,
+        );
+    }
+}
+```
+
+Then, reference this class in the `config/purify.php` file in the `css-definitions` key:
+
+```php
+// config/purify.php
+
+'css-definitions' => \App\CustomCSSDefinition::class,
+```
+
+See the class HTMLPurifier_CSSDefinition in the HTMLPurifier library for other examples of what can be changed.
+
 ### Upgrading from v4 to v5
 
 To upgrade from v4, install the latest version by running the below command in the root of your project:

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ namespace App;
 use HTMLPurifier_CSSDefinition;
 use Stevebauman\Purify\Definitions\CssDefinition;
 
-class CustomCSSDefinition implements CssDefinition
+class CustomCssDefinition implements CssDefinition
 {
     /**
      * Apply rules to the CSS Purifier definition.

--- a/config/purify.php
+++ b/config/purify.php
@@ -79,7 +79,7 @@ return [
     | HTMLPurifier. When specifying a custom class, make sure it implements
     | the interface:
     |
-    |   \Stevebauman\Purify\Definitions\CSSDefinition
+    |   \Stevebauman\Purify\Definitions\CssDefinition
     |
     | Note that these definitions are applied to every Purifier instance.
     |

--- a/config/purify.php
+++ b/config/purify.php
@@ -72,6 +72,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTMLPurifier CSS definitions
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify a class that augments the CSS definitions used by
+    | HTMLPurifier. When specifying a custom class, make sure it implements
+    | the interface:
+    |
+    |   \Stevebauman\Purify\Definitions\CSSDefinition
+    |
+    | Note that these definitions are applied to every Purifier instance.
+    |
+    | CSS should be extending $definition->info['css-attribute'] = values
+    | See HTMLPurifier_CSSDefinition for further explanation
+    |
+    */
+
+    'css-definitions' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Serializer
     |--------------------------------------------------------------------------
     |

--- a/src/Definitions/CSSDefinition.php
+++ b/src/Definitions/CSSDefinition.php
@@ -9,7 +9,7 @@ interface CSSDefinition
     /**
      * Apply rules to the CSS Purifier definition.
      *
-     * @param  HTMLPurifier_CSSDefinition $definition
+     * @param HTMLPurifier_CSSDefinition $definition
      *
      * @return void
      */

--- a/src/Definitions/CSSDefinition.php
+++ b/src/Definitions/CSSDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Stevebauman\Purify\Definitions;
+
+use HTMLPurifier_CSSDefinition;
+
+interface CSSDefinition
+{
+    /**
+     * Apply rules to the CSS Purifier definition.
+     *
+     * @param  HTMLPurifier_CSSDefinition $definition
+     *
+     * @return void
+     */
+    public static function apply(HTMLPurifier_CSSDefinition $definition);
+}

--- a/src/Definitions/CssDefinition.php
+++ b/src/Definitions/CssDefinition.php
@@ -4,7 +4,7 @@ namespace Stevebauman\Purify\Definitions;
 
 use HTMLPurifier_CSSDefinition;
 
-interface CSSDefinition
+interface CssDefinition
 {
     /**
      * Apply rules to the CSS Purifier definition.

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -6,6 +6,7 @@ use HTMLPurifier_Config;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
+use Stevebauman\Purify\Definitions\CSSDefinition;
 use Stevebauman\Purify\Definitions\Definition;
 
 class PurifyManager extends Manager
@@ -197,6 +198,14 @@ class PurifyManager extends Manager
             $definitionsClass = $this->config->get('purify.definitions');
 
             if ($definitionsClass && is_a($definitionsClass, Definition::class, true)) {
+                $definitionsClass::apply($definition);
+            }
+        }
+
+        if ($definition = $htmlConfig->getCSSDefinition()) {
+            $definitionsClass = $this->config->get('purify.css-definitions');
+
+            if ($definitionsClass && is_a($definitionsClass, CSSDefinition::class, true)) {
                 $definitionsClass::apply($definition);
             }
         }

--- a/src/PurifyManager.php
+++ b/src/PurifyManager.php
@@ -6,7 +6,7 @@ use HTMLPurifier_Config;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
-use Stevebauman\Purify\Definitions\CSSDefinition;
+use Stevebauman\Purify\Definitions\CssDefinition;
 use Stevebauman\Purify\Definitions\Definition;
 
 class PurifyManager extends Manager
@@ -205,7 +205,7 @@ class PurifyManager extends Manager
         if ($definition = $htmlConfig->getCSSDefinition()) {
             $definitionsClass = $this->config->get('purify.css-definitions');
 
-            if ($definitionsClass && is_a($definitionsClass, CSSDefinition::class, true)) {
+            if ($definitionsClass && is_a($definitionsClass, CssDefinition::class, true)) {
                 $definitionsClass::apply($definition);
             }
         }

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -179,7 +179,7 @@ class FooCSSDefinition implements CSSDefinition
     public static function apply(HTMLPurifier_CSSDefinition $definition)
     {
         $definition->info['text-align'] = new \HTMLPurifier_AttrDef_Enum(
-            array('center', 'start', 'end'),
+            ['center', 'start', 'end'],
             false,
         );
     }

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -6,7 +6,7 @@ use HTMLPurifier_CSSDefinition;
 use HTMLPurifier_HTMLDefinition;
 use Illuminate\Support\Facades\File;
 use Stevebauman\Purify\Cache\CacheDefinitionCache;
-use Stevebauman\Purify\Definitions\CSSDefinition;
+use Stevebauman\Purify\Definitions\CssDefinition;
 use Stevebauman\Purify\Definitions\Definition;
 use Stevebauman\Purify\Facades\Purify;
 use Stevebauman\Purify\PurifyServiceProvider;
@@ -136,7 +136,7 @@ class PurifyTest extends TestCase
 
     public function test_custom_css_definitions_are_applied()
     {
-        $this->app['config']->set('purify.css-definitions', FooCSSDefinition::class);
+        $this->app['config']->set('purify.css-definitions', FooCssDefinition::class);
 
         $this->assertEquals(
             '<p>Test</p>',
@@ -173,7 +173,7 @@ class FooDefinition implements Definition
     }
 }
 
-class FooCSSDefinition implements CSSDefinition
+class FooCssDefinition implements CssDefinition
 {
     public static function apply(HTMLPurifier_CSSDefinition $definition)
     {

--- a/tests/PurifyTest.php
+++ b/tests/PurifyTest.php
@@ -162,7 +162,6 @@ class PurifyTest extends TestCase
             '<p style="text-align:end;">Test</p>',
             Purify::clean('<p style="text-align:end;">Test</p>')
         );
-
     }
 }
 
@@ -184,4 +183,3 @@ class FooCSSDefinition implements CSSDefinition
         );
     }
 }
-


### PR DESCRIPTION
This PR adds the ability to create custom CSS definitions to be able to setup a custom CSS definition.

In my case I was finding text-align was missing start and end values, it only supported right. left, and center out of the box so I needed to add start and end

https://developer.mozilla.org/en-US/docs/Web/CSS/text-align.

I've included an example in the readme on how to implement the text-align change, taking the code from HTMLPurify, and modifying the CSS allowed enum for text-align.