### PR TITLE
Add config option to disable clear command

### DIFF
--- a/config/purify.php
+++ b/config/purify.php
@@ -112,4 +112,25 @@ return [
     //    'cache' => \Stevebauman\Purify\Cache\FilesystemDefinitionCache::class,
     // ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Disable 'purify:clear' command
+    |--------------------------------------------------------------------------
+    |
+    | Here you may enable or disable the 'purify:clear' command.
+    |
+    | If you have configured Purify to utilize the CacheDefinitionCache in the serializer
+    | option, this command issues a Cache::clear() on the cache driver you have configured
+    | it to use.
+    |
+    | If you have configured Purify to utilize the FilesystemDefinitionCache in the serializer
+    | option, this command will clear the directory that you have configured it to store in.
+    | 
+    | You may wish to disable this command if you are not using a unique filesystem path or disk
+    | (via config/filesystems.php) or cache store (via config/cache.php) for Purify.
+    |
+    */
+
+    'disable_clear_command' => false,  
+
 ];

--- a/src/PurifyServiceProvider.php
+++ b/src/PurifyServiceProvider.php
@@ -17,7 +17,9 @@ class PurifyServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/purify.php', 'purify');
 
-        $this->commands(ClearCommand::class);
+        if (! config('purify.disable_clear_command', false)) {
+            $this->commands(ClearCommand::class);
+        }
 
         $this->app->singleton('purify', function ($app) {
             if ($cache = config('purify.serializer.cache')) {


### PR DESCRIPTION
This allows the `purify:clear` command to be disabled if we're not using a unique cache store. It prevents devs from trying to manually clear old definitions and unknowingly nuking the entire app's cache. In-memory cache stores always get cleared eventually (eg. when upgrading to a newer version), so letting old definitions persist until then isn't really a problem.

It defaults to `false` if the config key isn't present, so it's backwards compatible.