### PR TITLE
chore: prepare for laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,30 +13,30 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4]
-                laravel: [9.*, 8.*, 7.*]
+                php: [8.3, 8.2, 8.1]
+                laravel: [11.*, 10.*, 9.*]
                 dependency-version: [prefer-stable]
                 include:
+                    - laravel: 11.*
+                      testbench: 9.*
+                    - laravel: 10.*
+                      testbench: 8.*
                     - laravel: 9.*
                       testbench: 7.*
-                    - laravel: 8.*
-                      testbench: 6.*
-                    - laravel: 7.*
-                      testbench: 5.*
                 exclude:
-                    - laravel: 9.*
-                      php: 7.4
-                    - laravel: 7.*
+                    - laravel: 11.*
                       php: 8.1
+                    - laravel: 9.*
+                      php: 8.3
 
         name: ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ~/.composer/cache/files
                   key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,15 @@
     "require": {
         "php": ">=7.4",
         "ezyang/htmlpurifier": "^4.17",
-        "illuminate/contracts": "~7.0|~8.0|~9.0|~10.0",
-        "illuminate/support": "~7.0|~8.0|~9.0|~10.0"
+        "illuminate/contracts": "~7.0|~8.0|~9.0|~10.0|~11.0",
+        "illuminate/support": "~7.0|~8.0|~9.0|~10.0|~11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0|~9.0",
-        "orchestra/testbench": "~5.0|~6.0|~7.0"
+        "phpunit/phpunit": "~8.0|~9.0|~10.0",
+        "orchestra/testbench": "~5.0|~6.0|~7.0|~8.0|~9.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "archive": {
         "exclude": [
             "/tests"

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,13 @@
     "require": {
         "php": ">=7.4",
         "ezyang/htmlpurifier": "^4.17",
-        "illuminate/contracts": "~7.0|~8.0|~9.0|~10.0|~11.0",
-        "illuminate/support": "~7.0|~8.0|~9.0|~10.0|~11.0"
+        "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0|~9.0|~10.0",
-        "orchestra/testbench": "~5.0|~6.0|~7.0|~8.0|~9.0"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "archive": {
         "exclude": [
             "/tests"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Purify Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Purify Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This PR adds support for Laravel 11. It updates the test runner to only run tests on currently supported PHP-versions and Laravel 11, 10 and 9. It stops running tests on older versions, while it is still allowed to install this package on older versions (Laravel 7 and 8 on PHP >= 7.4).