### PR TITLE
Update the facade docblock to match its backing class

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ var_dump($cleaned);
 
 ##### Dynamic Configuration
 
-Need a different configuration for a single input? Pass in a configuration array into the second parameter:
+Need a different configuration for a single input? Pass in a configuration array to the `config` method:
 
-> **Note**: Configuration passed into the second parameter
+> **Note**: Configuration passed into the config method
 > is **not** merged with your default configuration.
 
 ```php

--- a/src/Facades/Purify.php
+++ b/src/Facades/Purify.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static \HTMLPurifier              getPurifier()
- * @method static array|string               clean(array|string $input, array $config = null)
+ * @method static array|string               clean(array|string $input)
  * @method static \Stevebauman\Purify\Purify config(string|array $driver = null)
  */
 class Purify extends Facade


### PR DESCRIPTION
I noticed that the autocompletion in Phpstorm is still suggesting passing a dynamic config as the second argument to the `clean` method. This is no longer supported and fails silently.

<img width="482" alt="Screenshot 2025-05-21 at 14 53 07" src="https://github.com/user-attachments/assets/f7036fff-1b8d-454f-94c7-0371d8cf8ef1" />

I've updated the docblock in the Purify Facade to match the PurifyManager's method signature. This fixes the issue in the screenshot.

I also removed any references to the second argument from the readme for consistency.